### PR TITLE
fixed several scripts with logical mistakes in the check

### DIFF
--- a/lib/scanners/network-ignore-broadcast-requests.sh
+++ b/lib/scanners/network-ignore-broadcast-requests.sh
@@ -4,6 +4,6 @@
 # tags: CCE-26883-9
 # solution-cmd: echo 'net.ipv4.icmp_echo_ignore_broadcasts=1' >/etc/sysctl.d/50-icmp_echo_ignore_broadcasts.conf && sysctl -p
 
-if [[ $(/sbin/sysctl -n net.ipv4.icmp_echo_ignore_broadcasts 2>/dev/null) == 1 ]]; then
+if [[ $(/sbin/sysctl -n net.ipv4.icmp_echo_ignore_broadcasts 2>/dev/null) == 0 ]]; then
 	result_failed "net.ipv4.icmp_echo_ignore_broadcasts is not 1"
 fi

--- a/lib/scanners/network-no-ip-src-routing.sh
+++ b/lib/scanners/network-no-ip-src-routing.sh
@@ -4,6 +4,6 @@
 # tags: CCE-27037-1
 # solution-cmd: echo 'net.ipv4.conf.all.accept_source_route' >/etc/sysctl.d/50-net.ipv4.conf.all.accept_source_route.conf && sysctl -p
 
-if [[ $(/sbin/sysctl -n net.ipv4.conf.all.accept_source_route 2>/dev/null) == 0 ]]; then
+if [[ $(/sbin/sysctl -n net.ipv4.conf.all.accept_source_route 2>/dev/null) != 0 ]]; then
 	result_failed "net.ipv4.conf.all.accept_source_route is not 0"
 fi

--- a/lib/scanners/network-syn-cookies-on.sh
+++ b/lib/scanners/network-syn-cookies-on.sh
@@ -4,6 +4,6 @@
 # tags: CCE-27053-8
 # solution-cmd: echo 'net.ipv4.tcp_syncookies=1' >/etc/sysctl.d/50-net.ipv4.tcp_syncookies.conf
 
-if [[ $(/sbin/sysctl -n net.ipv4.tcp_syncookies 2>/dev/null) == 1 ]]; then
+if [[ $(/sbin/sysctl -n net.ipv4.tcp_syncookies 2>/dev/null) == 0 ]]; then
 	result_failed "net.ipv4.tcp_syncookies is not enabled"
 fi

--- a/lib/scanners/security-nx-enabled.sh
+++ b/lib/scanners/security-nx-enabled.sh
@@ -3,7 +3,7 @@
 # description: On Intel CPUs execute disable protection should be active
 # tags: CCE-27001-4
 
-if [[ $(dmesg | grep '[NX|DX]*protection: active') != "" ]]; then
+if [[ $(dmesg | grep '[NX|DX]*protection: active') == "" ]]; then
 	result_failed "Intel Execute Disable support not active!"
 fi
 


### PR DESCRIPTION
Hi while using the scripts I found several logical mistakes in the scanners that check both some kernel variables as well as NX via dmesg. 